### PR TITLE
Changes in code and test file to break the pytest and linter

### DIFF
--- a/FilterCode.py
+++ b/FilterCode.py
@@ -13,15 +13,16 @@ class Filter2:  # Class for the filter
             raise ValueError("Wrong input text.")
 
         if Lvalue > 0 and Cvalue > 0 and Rvalue >= 0:
-            self.Lvalue = Lvalue
+            self.Lvalue=Lvalue  # Testing linter, should be: self.Lvalue = Lvalue
             self.Cvalue = Cvalue
             self.Rvalue = Rvalue  # Saves all the atributes is a objekt self
         else:
             raise ValueError("All component values must be positive.")
 
     # This function calculates the resonans point for the filter and then prints it
-    def get_resonance_point(self):
-        resonansFreq = 1 / (2 * math.pi * math.sqrt(self.Lvalue * self.Cvalue))
+    # Added a redundant variable (redundantVariable) to fail workflows (and will also break the linter)
+    def get_resonance_point(self, redundantVariable):
+        resonansFreq = 1 / (2 * math.pi * math.sqrt(self.Lvalue * self.Cvalue)) + redundantVariable
         return round(resonansFreq, 4)
 
     # This function calculates the damping factor for the filter and then prints it

--- a/test_FilterCode.py
+++ b/test_FilterCode.py
@@ -12,8 +12,9 @@ class TestFilter(unittest.TestCase):
         )
 
     def test_get_damping_factor(self):  # Checks numerical value for the damping factor
-        self.assertAlmostEqual(Filter2("HP", 5, 2, 3).get_damping_factor(), 0.9487)
-
+        # Changed value to make unit test raise an error (correct value is 0.9487)
+        self.assertAlmostEqual(Filter2("HP", 5, 2, 3).get_damping_factor(), 10)
+        
     def test_get_transfer(self):  # Check the output string for the transfer function
         transferLP = "1 / (s^2*{} + s*{} + 1)".format(20, 12)
         transferHP = "(s^2*{}) / (s^2*{} + s*{} + 1)".format(20, 20, 12)


### PR DESCRIPTION
In FilterCode.py, I removed some spaces to raise an error regarding the linter. Additionally, I added an extra argument to one of the functions to cause a pytest error.

In test_FilterCode.py, I modified one of the test values to raise another pytest error.